### PR TITLE
Remove trailing comma in some payloads

### DIFF
--- a/payloads/1058.json
+++ b/payloads/1058.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1058 [GHOSTSCRIPT_CVE_2017_8291]",
   "description": "Rektosaurus #1058 [GHOSTSCRIPT_CVE_2017_8291]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2017-8291/type_confusion_nslookup_dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2017-8291/type_confusion_nslookup_dnsbased.jpg"
 }

--- a/payloads/1059.json
+++ b/payloads/1059.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1059 [CMDINJ_CVE_2020_29599]",
   "description": "Rektosaurus #1059 [CMDINJ_CVE_2020_29599]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/Shell_Injection_CVE-2020-29599/cve-2020-29599-nslookup-dnsbased.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/Shell_Injection_CVE-2020-29599/cve-2020-29599-nslookup-dnsbased.svg"
 }

--- a/payloads/1060.json
+++ b/payloads/1060.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1060 [SSRF_FEIMAGE_XLINK_HREF]",
   "description": "Rektosaurus #1060 [SSRF_FEIMAGE_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-feimage-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-feimage-xlink-href.svg"
 }

--- a/payloads/1061.json
+++ b/payloads/1061.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1061 [SSRF_FOREIGNOBJECT_IFRAME_SRC]",
   "description": "Rektosaurus #1061 [SSRF_FOREIGNOBJECT_IFRAME_SRC]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-foreignobject-iframe-src.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-foreignobject-iframe-src.svg"
 }

--- a/payloads/1062.json
+++ b/payloads/1062.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1062 [SSRF_FOREIGNOBJECT_IMG_SRC]",
   "description": "Rektosaurus #1062 [SSRF_FOREIGNOBJECT_IMG_SRC]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-foreignobject-img-src.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-foreignobject-img-src.svg"
 }

--- a/payloads/1063.json
+++ b/payloads/1063.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1063 [SSRF_IMAGE_HREF]",
   "description": "Rektosaurus #1063 [SSRF_IMAGE_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-image-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-image-href.svg"
 }

--- a/payloads/1064.json
+++ b/payloads/1064.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1063 [SSRF_IMAGE_XLINK_HREF]",
   "description": "Rektosaurus #1063 [SSRF_IMAGE_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-image-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-image-xlink-href.svg"
 }

--- a/payloads/1065.json
+++ b/payloads/1065.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1065 [GHOSTSCRIPT_CVE_2018_16509]",
   "description": "Rektosaurus #1065 [GHOSTSCRIPT_CVE_2018_16509]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2018-16509/ubuntu_nslookup_dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2018-16509/ubuntu_nslookup_dnsbased.jpg"
 }

--- a/payloads/1067.json
+++ b/payloads/1067.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1067 [SSRF_USE_XLINK_HREF]",
   "description": "Rektosaurus #1067 [SSRF_USE_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-use-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-use-xlink-href.svg"
 }

--- a/payloads/1068.json
+++ b/payloads/1068.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1068 [SSRF_XI_INCLUDE]",
   "description": "Rektosaurus #1068 [SSRF_XI_INCLUDE]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-xi-include.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-xi-include.svg"
 }

--- a/payloads/1069.json
+++ b/payloads/1069.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1069 [SSRF_XML_STYLESHEET]",
   "description": "Rektosaurus #1069 [SSRF_XML_STYLESHEET]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-xml-stylesheet.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-xml-stylesheet.svg"
 }

--- a/payloads/1070.json
+++ b/payloads/1070.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1070 [XSS]",
   "description": "Rektosaurus #1070 [XSS]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/XSS/xss.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/XSS/xss.svg"
 }

--- a/payloads/1071.json
+++ b/payloads/1071.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1071 [XXE_INTERNAL_ENTITIES]",
   "description": "Rektosaurus #1071 [XXE_INTERNAL_ENTITIES]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-internal-entities.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-internal-entities.svg"
 }

--- a/payloads/1072.json
+++ b/payloads/1072.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1072 [XXE_LOCAL_FILE_READ]",
   "description": "Rektosaurus #1072 [XXE_LOCAL_FILE_READ]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-local-file-read.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-local-file-read.svg"
 }

--- a/payloads/1073.json
+++ b/payloads/1073.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1073 [GHOSTSCRIPT_CVE_2019_14811]",
   "description": "Rektosaurus #1073 [GHOSTSCRIPT_CVE_2019_14811]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-14811-nslookup-dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-14811-nslookup-dnsbased.jpg"
 }

--- a/payloads/1074.json
+++ b/payloads/1074.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1074 [GHOSTSCRIPT_CVE_2019_14812]",
   "description": "Rektosaurus #1074 [GHOSTSCRIPT_CVE_2019_14812]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-6116-nslookup-dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-6116-nslookup-dnsbased.jpg"
 }

--- a/payloads/1075.json
+++ b/payloads/1075.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1075 [GHOSTSCRIPT_CVE_2019_6116]",
   "description": "Rektosaurus #1075 [GHOSTSCRIPT_CVE_2019_6116]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-6116/cve-2019-6116-nslookup-dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-6116/cve-2019-6116-nslookup-dnsbased.jpg"
 }

--- a/payloads/1076.json
+++ b/payloads/1076.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1076 [GHOSTSCRIPT_CVE_2019_10216]",
   "description": "Rektosaurus #1076 [GHOSTSCRIPT_CVE_2019_10216]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-10216/cve-2019-10216-nslookup-dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-10216/cve-2019-10216-nslookup-dnsbased.jpg"
 }

--- a/payloads/1077.json
+++ b/payloads/1077.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1077 [GIFOEB_CVE_2017_15277]",
   "description": "Rektosaurus #1077 [GIFOEB_CVE_2017_15277]",
-  "image": "https://rex.rektosaurus.io/exploits/MemoryLeaks/GIF_CVE-2017-15277/300x300.gif",
+  "image": "https://rex.rektosaurus.io/exploits/MemoryLeaks/GIF_CVE-2017-15277/300x300.gif"
 }

--- a/payloads/1078.json
+++ b/payloads/1078.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1078 [XBM_CVE_2018_16323]",
   "description": "Rektosaurus #1078 [XBM_CVE_2018_16323]",
-  "image": "https://rex.rektosaurus.io/exploits/MemoryLeaks/XBM_CVE-2018-16323/poc-500.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/MemoryLeaks/XBM_CVE-2018-16323/poc-500.jpg"
 }

--- a/payloads/1079.json
+++ b/payloads/1079.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1079 [GRAPHICSMAGICK_CVE_2019_12921]",
   "description": "Rektosaurus #1079 [GRAPHICSMAGICK_CVE_2019_12921]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/GraphicsMagick_CVE-2019-12921/attribute_remote_google_pic.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/GraphicsMagick_CVE-2019-12921/attribute_remote_google_pic.svg"
 }

--- a/payloads/1080.json
+++ b/payloads/1080.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1080 [IMAGETRAGICK_CVE_2016_3714]",
   "description": "Rektosaurus #1080 [IMAGETRAGICK_CVE_2016_3714]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/ImageTragick_CVE-2016-3714/rce-svg-dnsbased.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/ImageTragick_CVE-2016-3714/rce-svg-dnsbased.svg"
 }

--- a/payloads/1081.json
+++ b/payloads/1081.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #10681 [SSRF_LINK_HREF]",
   "description": "Rektosaurus #1081 [SSRF_LINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-link-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-link-href.svg"
 }

--- a/payloads/1082.json
+++ b/payloads/1082.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1082 [SSRF_PATH_FILL]",
   "description": "Rektosaurus #1082 [SSRF_PATH_FILL]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-path-fill.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-path-fill.svg"
 }

--- a/payloads/1083.json
+++ b/payloads/1083.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1083 [SSRF_PATTERN_IMAGE_XLINK_HREF]",
   "description": "Rektosaurus #1083 [SSRF_PATTERN_IMAGE_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-pattern-image-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-pattern-image-xlink-href.svg"
 }

--- a/payloads/1084.json
+++ b/payloads/1084.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1084 [SSRF_RECT_FILL_SMB]",
   "description": "Rektosaurus #1084 [SSRF_RECT_FILL_SMB]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-rect-fill-smb.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-rect-fill-smb.svg"
 }

--- a/payloads/1085.json
+++ b/payloads/1085.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1085 [SSRF_RECT_FILL]",
   "description": "Rektosaurus #1085 [SSRF_RECT_FILL]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-rect-fill.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-rect-fill.svg"
 }

--- a/payloads/1086.json
+++ b/payloads/1086.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1086 [SSRF_STYLE_CDATA_FONT_SRC]",
   "description": "Rektosaurus #1086 [SSRF_STYLE_CDATA_FONT_SRC]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-cdata-font-src.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-cdata-font-src.svg"
 }

--- a/payloads/1087.json
+++ b/payloads/1087.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1087 [SSRF_STYLE_CDATA_IMPORT_URL]",
   "description": "Rektosaurus #1087 [SSRF_STYLE_CDATA_IMPORT_URL]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-cdata-import-url.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-cdata-import-url.svg"
 }

--- a/payloads/1088.json
+++ b/payloads/1088.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1088 [SSRF_STYLE_IMPORT]",
   "description": "Rektosaurus #1088 [SSRF_STYLE_IMPORT]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-import.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-style-import.svg"
 }

--- a/payloads/1089.json
+++ b/payloads/1089.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1089 [SSRF_TREF_XLINK_HREF]",
   "description": "Rektosaurus #1089 [SSRF_TREF_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-tref-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-tref-xlink-href.svg"
 }

--- a/payloads/1090.json
+++ b/payloads/1090.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1090 [SSRF_TEXTPATH_XLINK_HREF]",
   "description": "Rektosaurus #1090 [SSRF_TEXTPATH_XLINK_HREF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-textpath-xlink-href.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/SSRF/ssrf-textpath-xlink-href.svg"
 }

--- a/payloads/1091.json
+++ b/payloads/1091.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1091 [GHOSTSCRIPT_0DAY_RCE]",
   "description": "Rektosaurus #1091 [GHOSTSCRIPT_0DAY_RCE]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/0day/image.svg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/0day/image.svg"
 }

--- a/payloads/1092.json
+++ b/payloads/1092.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1092 [XXE_SSRF]",
   "description": "Rektosaurus #1092 [XXE_SSRF]",
-  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-ssrf.svg",
+  "image": "https://rex.rektosaurus.io/exploits/SVG/XXE/xxe-ssrf.svg"
 }

--- a/payloads/1093.json
+++ b/payloads/1093.json
@@ -1,5 +1,5 @@
 {
   "name": "Rektosaurus #1093 [GHOSTSCRIPT_CVE_2019_14813]",
   "description": "Rektosaurus #1093 [GHOSTSCRIPT_CVE_2019_14813]",
-  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-14813-nslookup-dnsbased.jpg",
+  "image": "https://rex.rektosaurus.io/exploits/GhostScript/CVE-2019-1481X/cve-2019-14813-nslookup-dnsbased.jpg"
 }


### PR DESCRIPTION
Some json payloads have trailing commas in the code. This causes `JSON.parse()` to fail. This PR removes extra commas in the payloads